### PR TITLE
use network-online.target

### DIFF
--- a/jessie/overlay-image-tools/etc/systemd/system/scw-sync-kernel-modules.service
+++ b/jessie/overlay-image-tools/etc/systemd/system/scw-sync-kernel-modules.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SCW fetch kernel modules from Scaleway mirror
-After=NetworkManager-wait-online.service
+After=network-online.target
 
 [Service]
 ExecStart=/usr/local/sbin/scw-sync-kernel-modules

--- a/sid/overlay-image-tools/etc/systemd/system/scw-sync-kernel-modules.service
+++ b/sid/overlay-image-tools/etc/systemd/system/scw-sync-kernel-modules.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SCW fetch kernel modules from Scaleway mirror
-After=NetworkManager-wait-online.service
+After=network-online.target
 
 [Service]
 ExecStart=/usr/local/sbin/scw-sync-kernel-modules


### PR DESCRIPTION
Use the generic network-online.target, as it works with all network
management tools.