### PR TITLE
Deprecate Jessie arm64 after EOL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
     "jessie": {
         "directory": "jessie",
         "architectures": [
-            "arm", "arm64", "x86_64"
+            "arm", "x86_64"
         ],
         "marketplace-id": "fb619bdf-834e-4c71-b7b8-15b5546d18bd"
     },


### PR DESCRIPTION
arm64 is not supported as a LTS architecture on Jessie: https://wiki.debian.org/LTS