### PR TITLE
Fix break

### DIFF
--- a/buster/overlay/usr/local/sbin/scw-net-ipv6
+++ b/buster/overlay/usr/local/sbin/scw-net-ipv6
@@ -27,9 +27,9 @@ iface $iface inet6 static
 	netmask $IPV6_NMASK
 	gateway $IPV6_GW
 EOF
+                # only assign to the first physical interface
+                break;
                 fi
-	# only assign to the first physical interface
-	break;
         done
 fi
 


### PR DESCRIPTION
IPv6 was not working on my Scaleway DEV1-S Debian Buster instance (PAR 1). This patch fixes the problem.

I have installed Docker on that instance. I have the following interfaces:

```
# for iface in $(ls /sys/class/net); do
> readlink /sys/class/net/$iface
> done
../../devices/virtual/net/br-1f5938c3bac4
../../devices/virtual/net/br-3fd5460638c6
../../devices/virtual/net/docker0
../../devices/pci0000:00/0000:00:02.0/virtio0/net/ens2
../../devices/virtual/net/lo
../../devices/virtual/net/veth120bc9b
../../devices/virtual/net/veth2ab37fe
../../devices/virtual/net/vetha97645f
../../devices/virtual/net/vethd3f2be4
../../devices/virtual/net/vethe22e9d0
../../devices/virtual/net/vethe4eb87e
```

The `scw-net-ipv6` was breaking right after the first interface, so IPv6 was not configured for `ens2`. Changing the `break` position solved the problem.